### PR TITLE
Rearrange plaque layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,16 +63,16 @@
             <div class="tap-zone tap-zone-left" id="tap-zone-left"></div>
             <div class="tap-zone tap-zone-right" id="tap-zone-right"></div>
             <div class="artwork-frame" id="current-artwork-frame">
-                <div class="artwork-image" id="current-artwork-image">
-                    <img id="artwork-img" class="gallery-glow" src="assets/image/HighlandCoveredBridge.jpg" alt="Highland Covered Bridge" style="max-width: 100%; max-height: 100%; display: block; margin: 0 auto;" />
-                    <button class="ar-btn" id="ar-btn" title="View in AR">View in AR</button>
-                </div>
+                <h2 class="artwork-title" id="artwork-title">Highland Covered Bridge</h2>
+                <p class="artwork-artist" id="artwork-artist">by Alyson Hatcher-Kendall</p>
                 <div class="artwork-plaque" id="artwork-plaque">
-                    <h2 class="artwork-title" id="artwork-title">Highland Covered Bridge</h2>
-                    <p class="artwork-artist" id="artwork-artist">by Alyson Hatcher-Kendall</p>
-                    <p class="artwork-details" id="artwork-details">acrylic on marine board • 4' x 4' • $300</p>
+                    <div class="artwork-image" id="current-artwork-image">
+                        <img id="artwork-img" class="gallery-glow" src="assets/image/HighlandCoveredBridge.jpg" alt="Highland Covered Bridge" style="max-width: 100%; max-height: 100%; display: block; margin: 0 auto;" />
+                    </div>
                 </div>
-            </div>
+                <p class="artwork-details" id="artwork-details">acrylic on marine board • 4' x 4' • $300</p>
+                <button class="ar-btn" id="ar-btn" title="View in AR">View in AR</button>
+                </div>
         </div>
 
         <!-- Foreground Elements -->


### PR DESCRIPTION
## Summary
- move artwork title and artist above the plaque
- keep only the image inside the plaque container and move details below

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880155b4a04832899132649139a001e